### PR TITLE
Implement scrapers and enforce placeholder checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: no-placeholders
+        name: No placeholders or duplicate lines
+        entry: scripts/no_placeholders.py
+        language: script
+        files: '\.py$'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,5 @@
 - Target an average of roughly 300 lines per file across the codebase.
 - Adopt a test-driven development (TDD) approach by writing or updating tests before implementing features or fixes.
 - Run `pytest` and execute `python harvester.py` when modifying code to ensure functionality.
+- Do not commit placeholders, stubs, or unfinished logic; all code must be fully implemented.
 - Avoid committing generated files (e.g., logs, `__pycache__`).

--- a/scrapers/craigslist.py
+++ b/scrapers/craigslist.py
@@ -1,15 +1,38 @@
-"""Placeholder scraper for Craigslist."""
+"""Scraper for Craigslist software job listings."""
 
 from __future__ import annotations
 
+import datetime as dt
+import email.utils as eut
+import xml.etree.ElementTree as ET
 from typing import List
+
+import requests
 
 from .base import Lead, Scraper
 
+RSS_URL = "https://newyork.craigslist.org/search/sof?format=rss"
+
 
 class CraigslistScraper(Scraper):
-    """Scrape freelance leads from Craigslist."""
+    """Fetch freelance leads from Craigslist RSS feed."""
 
     def fetch(self) -> List[Lead]:
-        # TODO: implement Craigslist scraping
-        return []
+        try:
+            response = requests.get(RSS_URL, headers={"User-Agent": "contract-leads"}, timeout=30)
+            response.raise_for_status()
+            root = ET.fromstring(response.content)
+        except requests.RequestException:
+            return []
+        leads: List[Lead] = []
+        for item in root.findall(".//item"):
+            title = item.findtext("title", default="")
+            url = item.findtext("link", default="")
+            description = item.findtext("description", default="")
+            pubdate = item.findtext("pubDate")
+            try:
+                posted = eut.parsedate_to_datetime(pubdate) if pubdate else dt.datetime.now(dt.timezone.utc)
+            except (TypeError, ValueError):
+                posted = dt.datetime.now(dt.timezone.utc)
+            leads.append(Lead(title=title, url=url, description=description, posted=posted))
+        return leads

--- a/scrapers/reddit.py
+++ b/scrapers/reddit.py
@@ -1,15 +1,34 @@
-"""Placeholder scraper for Reddit."""
+"""Scraper for Reddit /r/forhire posts."""
 
 from __future__ import annotations
 
+import datetime as dt
 from typing import List
+
+import requests
 
 from .base import Lead, Scraper
 
+API_URL = "https://www.reddit.com/r/forhire/new.json?limit=10"
+
 
 class RedditScraper(Scraper):
-    """Scrape freelance leads from Reddit."""
+    """Fetch freelance leads from Reddit."""
 
     def fetch(self) -> List[Lead]:
-        # TODO: implement Reddit scraping
-        return []
+        try:
+            response = requests.get(API_URL, headers={"User-Agent": "contract-leads"}, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+        except requests.RequestException:
+            return []
+        leads: List[Lead] = []
+        children = data.get("data", {}).get("children", [])
+        for child in children:
+            post = child.get("data", {})
+            title = post.get("title", "")
+            url = "https://www.reddit.com" + post.get("permalink", "")
+            description = post.get("selftext", "")
+            posted = dt.datetime.fromtimestamp(post.get("created_utc", 0), tz=dt.timezone.utc)
+            leads.append(Lead(title=title, url=url, description=description, posted=posted))
+        return leads

--- a/scrapers/weworkremotely.py
+++ b/scrapers/weworkremotely.py
@@ -1,15 +1,38 @@
-"""Placeholder scraper for WeWorkRemotely."""
+"""Scraper for WeWorkRemotely listings."""
 
 from __future__ import annotations
 
+import datetime as dt
+import email.utils as eut
+import xml.etree.ElementTree as ET
 from typing import List
+
+import requests
 
 from .base import Lead, Scraper
 
+RSS_URL = "https://weworkremotely.com/categories/remote-programming-jobs.rss"
+
 
 class WeWorkRemotelyScraper(Scraper):
-    """Scrape freelance leads from WeWorkRemotely."""
+    """Fetch freelance leads from WeWorkRemotely RSS feed."""
 
     def fetch(self) -> List[Lead]:
-        # TODO: implement WeWorkRemotely scraping
-        return []
+        try:
+            response = requests.get(RSS_URL, headers={"User-Agent": "contract-leads"}, timeout=30)
+            response.raise_for_status()
+            root = ET.fromstring(response.content)
+        except requests.RequestException:
+            return []
+        leads: List[Lead] = []
+        for item in root.findall(".//item"):
+            title = item.findtext("title", default="")
+            url = item.findtext("link", default="")
+            description = item.findtext("description", default="")
+            pubdate = item.findtext("pubDate")
+            try:
+                posted = eut.parsedate_to_datetime(pubdate) if pubdate else dt.datetime.now(dt.timezone.utc)
+            except (TypeError, ValueError):
+                posted = dt.datetime.now(dt.timezone.utc)
+            leads.append(Lead(title=title, url=url, description=description, posted=posted))
+        return leads

--- a/scripts/no_placeholders.py
+++ b/scripts/no_placeholders.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to reject unfinished code markers and duplicate lines."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLACEHOLDERS = ["TODO", "FIXME", "pass", "NotImplementedError", "placeholder", "..."]
+
+def check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    previous: str | None = None
+    if path.name == "no_placeholders.py":
+        return errors
+    try:
+        text = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return errors
+    for idx, line in enumerate(text, 1):
+        stripped = line.strip()
+        if "PLACEHOLDERS" in line:
+            continue
+        for token in PLACEHOLDERS:
+            if token in line:
+                errors.append(f"{path}:{idx}: found placeholder '{token}'")
+        if previous is not None and stripped and stripped == previous and stripped not in {')', ']', '}'}:
+            errors.append(f"{path}:{idx}: duplicate line '{stripped}'")
+        previous = stripped
+    return errors
+
+def main(argv: list[str]) -> int:
+    all_errors: list[str] = []
+    for file_name in argv:
+        path = Path(file_name)
+        if path.is_file():
+            all_errors.extend(check_file(path))
+    if all_errors:
+        print("\n".join(all_errors))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -1,0 +1,71 @@
+"""Tests for scraper implementations."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scrapers.craigslist import CraigslistScraper
+from scrapers.reddit import RedditScraper
+from scrapers.weworkremotely import WeWorkRemotelyScraper
+
+
+def make_response(*, text: str | None = None, json_data: dict | None = None) -> Mock:
+    response = Mock()
+    response.raise_for_status.return_value = None
+    if text is not None:
+        response.content = text.encode("utf-8")
+    if json_data is not None:
+        response.json.return_value = json_data
+    else:
+        response.json.return_value = {}
+    return response
+
+
+def test_weworkremotely_fetch() -> None:
+    rss = (
+        "<rss><channel><item><title>Job</title><link>http://ex.com</link>"
+        "<description>desc</description><pubDate>Wed, 01 Jan 2020 00:00:00 +0000"\
+        "</pubDate></item></channel></rss>"
+    )
+    with patch("requests.get", return_value=make_response(text=rss)):
+        leads = WeWorkRemotelyScraper().fetch()
+    assert len(leads) == 1
+    assert leads[0].title == "Job"
+    assert leads[0].url == "http://ex.com"
+
+
+def test_craigslist_fetch() -> None:
+    rss = (
+        "<rss><channel><item><title>CL Job</title><link>http://cl.com</link>"
+        "<description>desc</description><pubDate>Wed, 01 Jan 2020 00:00:00 +0000"\
+        "</pubDate></item></channel></rss>"
+    )
+    with patch("requests.get", return_value=make_response(text=rss)):
+        leads = CraigslistScraper().fetch()
+    assert len(leads) == 1
+    assert leads[0].url == "http://cl.com"
+
+
+def test_reddit_fetch() -> None:
+    data = {
+        "data": {
+            "children": [
+                {
+                    "data": {
+                        "title": "Reddit Job",
+                        "permalink": "/r/test",
+                        "selftext": "desc",
+                        "created_utc": 1609459200,
+                    }
+                }
+            ]
+        }
+    }
+    with patch("requests.get", return_value=make_response(json_data=data)):
+        leads = RedditScraper().fetch()
+    assert len(leads) == 1
+    assert leads[0].title == "Reddit Job"


### PR DESCRIPTION
## Summary
- forbid placeholders by updating repo guidelines and adding a pre-commit hook
- implement Craigslist, Reddit, and WeWorkRemotely scrapers
- add tests covering each scraper

## Testing
- `pre-commit run --files scripts/no_placeholders.py scrapers/weworkremotely.py scrapers/craigslist.py scrapers/reddit.py tests/test_scrapers.py`
- `pytest`
- `python harvester.py --lead_quality_score 1 --response_rate 1 --close_rate 1 --daily_potential_revenue 1`


------
https://chatgpt.com/codex/tasks/task_e_689763398bac8329b7a948e8d5f6ad5f