### PR TITLE
Enable dynamic loading of extra lead scrapers

### DIFF
--- a/extra_sources/loader.py
+++ b/extra_sources/loader.py
@@ -1,0 +1,25 @@
+"""Utilities for discovering extra scrapers."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from inspect import isclass
+from pathlib import Path
+from typing import List
+
+from scrapers.base import Scraper
+
+
+def load_extra_scrapers() -> List[Scraper]:
+    """Dynamically load ``Scraper`` subclasses from the ``extra_sources`` package."""
+    scrapers: List[Scraper] = []
+    pkg_path = Path(__file__).parent
+    for py_file in pkg_path.glob("*.py"):
+        if py_file.name in {"__init__.py", "loader.py"}:
+            continue
+        module_name = f"{pkg_path.name}.{py_file.stem}"
+        module = import_module(module_name)
+        for obj in module.__dict__.values():
+            if isclass(obj) and issubclass(obj, Scraper) and obj is not Scraper:
+                scrapers.append(obj())
+    return scrapers

--- a/lead_harvester.py
+++ b/lead_harvester.py
@@ -15,6 +15,7 @@ from scoring import LeadScorer
 from outputs import export_all
 from alerts import AlertSystem
 from outreach import OutreachGenerator
+from extra_sources.loader import load_extra_scrapers
 
 
 def main() -> None:
@@ -25,6 +26,7 @@ def main() -> None:
         RedditScraper(),
         WeWorkRemotelyScraper(),
     ]
+    scrapers.extend(load_extra_scrapers())
     leads = []
     for scraper in scrapers:
         leads.extend(scraper.fetch())

--- a/tests/test_extra_loader.py
+++ b/tests/test_extra_loader.py
@@ -1,0 +1,30 @@
+"""Tests for dynamic loading of extra scrapers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from extra_sources.loader import load_extra_scrapers
+
+
+def test_load_extra_scrapers_discovers_custom_scrapers() -> None:
+    pkg_path = Path(__file__).resolve().parents[1] / "extra_sources"
+    mod_path = pkg_path / "dummy_source.py"
+    mod_path.write_text(
+        "from scrapers.base import Scraper, Lead\n"
+        "import datetime as dt\n"
+        "class DummyScraper(Scraper):\n"
+        "    def fetch(self):\n"
+        "        return [Lead(title='d', url='u', description='x', posted=dt.datetime.now(dt.timezone.utc))]\n"
+    )
+    try:
+        importlib.invalidate_caches()
+        scrapers = load_extra_scrapers()
+        assert any(s.__class__.__name__ == "DummyScraper" for s in scrapers)
+    finally:
+        mod_path.unlink()
+        importlib.invalidate_caches()


### PR DESCRIPTION
## Summary
- load custom scrapers from the `extra_sources` package automatically
- expand harvester to use dynamically discovered scrapers
- test dynamic scraper loading behavior

## Testing
- `pytest`
- `python harvester.py --lead_quality_score 10 --response_rate 30 --close_rate 10 --daily_potential_revenue 300`


------
https://chatgpt.com/codex/tasks/task_e_6897666e9e80832996643f7da4927786