### PR TITLE
Enhance lead scoring heuristics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,10 @@ budget:
 scoring:
   keyword_weight: 1.0
   recency_weight: 0.5
+  urgency_weight: 2.0
+  budget_weight: 1.5
+  decision_maker_weight: 1.0
+  dm_friendliness_weight: 1.0
 pricing:
   base: 1000
 telegram:

--- a/scoring.py
+++ b/scoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -18,16 +19,47 @@ class ScoredLead:
 
 
 class LeadScorer:
-    """Score leads based on simple keyword and recency heuristics."""
+    """Score leads using keyword and heuristic signals."""
 
     def __init__(self, config: Dict):
         self.keywords = [k.lower() for k in config.get("keywords", [])]
         self.weights = config.get("scoring", {})
+        budget = config.get("budget", {})
+        self.budget_min = budget.get("min", 0)
+        self.budget_max = budget.get("max", 0)
+        self.urgency_words = ["asap", "urgent", "immediately", "today"]
+        self.decision_phrases = [
+            "my business",
+            "my store",
+            "i need",
+            "we need",
+            "i'm looking",
+        ]
 
     def score(self, lead: Lead) -> ScoredLead:
         text = f"{lead.title} {lead.description}".lower()
+        score = 0.0
+
         keyword_hits = sum(text.count(k) for k in self.keywords)
-        keyword_score = keyword_hits * self.weights.get("keyword_weight", 1.0)
+        score += keyword_hits * self.weights.get("keyword_weight", 1.0)
+
         days_old = (dt.datetime.now(dt.timezone.utc) - lead.posted).days
-        recency_score = max(0.0, self.weights.get("recency_weight", 0.5) * (30 - days_old))
-        return ScoredLead(lead=lead, score=keyword_score + recency_score)
+        score += max(0.0, self.weights.get("recency_weight", 0.5) * (30 - days_old))
+
+        if any(w in text for w in self.urgency_words):
+            score += self.weights.get("urgency_weight", 0.0)
+
+        for match in re.findall(r"\$([0-9,]+)", text):
+            value = float(match.replace(",", ""))
+            if self.budget_min <= value <= self.budget_max:
+                score += self.weights.get("budget_weight", 0.0)
+                break
+
+        if any(p in text for p in self.decision_phrases):
+            score += self.weights.get("decision_maker_weight", 0.0)
+
+        word_count = len(lead.description.split())
+        if word_count <= 50:
+            score += self.weights.get("dm_friendliness_weight", 0.0)
+
+        return ScoredLead(lead=lead, score=score)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,59 @@
+"""Tests for the lead scoring engine."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scrapers.base import Lead
+from scoring import LeadScorer
+
+
+def make_lead(text: str) -> Lead:
+    return Lead(
+        title="t",
+        url="u",
+        description=text,
+        posted=dt.datetime.now(dt.timezone.utc),
+    )
+
+
+def test_scoring_combines_multiple_factors() -> None:
+    config = {
+        "keywords": ["python"],
+        "budget": {"min": 50, "max": 500},
+        "scoring": {
+            "keyword_weight": 1.0,
+            "recency_weight": 0.0,
+            "urgency_weight": 2.0,
+            "budget_weight": 1.5,
+            "decision_maker_weight": 1.0,
+            "dm_friendliness_weight": 1.0,
+        },
+    }
+    text = "Need Python script ASAP for my business, budget $200."
+    score = LeadScorer(config).score(make_lead(text)).score
+    expected = 1.0 + 2.0 + 1.5 + 1.0 + 1.0
+    assert score == pytest.approx(expected)
+
+
+def test_budget_out_of_range_not_scored() -> None:
+    config = {
+        "keywords": [],
+        "budget": {"min": 50, "max": 500},
+        "scoring": {
+            "keyword_weight": 0.0,
+            "recency_weight": 0.0,
+            "budget_weight": 1.0,
+        },
+    }
+    in_range = "Budget $200 available"
+    out_range = "Budget $1000 available"
+    scorer = LeadScorer(config)
+    assert scorer.score(make_lead(in_range)).score == pytest.approx(1.0)
+    assert scorer.score(make_lead(out_range)).score == 0.0


### PR DESCRIPTION
## Summary
- score leads using urgency, budget range, decision-maker language and message brevity
- configure weights for new heuristics in `config.yaml`
- add unit tests verifying scoring behaviour

## Testing
- `pytest`
- `python harvester.py --lead_quality_score 10 --response_rate 30 --close_rate 10 --daily_potential_revenue 300`


------
https://chatgpt.com/codex/tasks/task_e_689768462c8083298d0a93b1fd4d5f30